### PR TITLE
Added hover effect/finished drag/drop functionality for Side/Extra Deck

### DIFF
--- a/frontend/src/components/deckcomponents/decksidebar/collectiondisplaycomponent.tsx
+++ b/frontend/src/components/deckcomponents/decksidebar/collectiondisplaycomponent.tsx
@@ -15,9 +15,9 @@ const CollectionDisplayComponent = ({ CollectionDisplayCompProps }: CollectionDi
     return (
         <>
             {listView && (
-                <div className="flex w-full h-full py-2">
+                <div className="flex w-full h-full">
                         {collectionListResults.length > 0 ? (
-                            <div className="flex flex-col space-y-3">
+                            <div className="flex flex-col space-y-2">
                                 {collectionCurrentListResults.map((result) => (
                                     <CollectionListViewItem result={result} />
                                 ))}

--- a/frontend/src/components/deckcomponents/editdeckcomponents/ExtraDeckCardsZone.tsx
+++ b/frontend/src/components/deckcomponents/editdeckcomponents/ExtraDeckCardsZone.tsx
@@ -1,0 +1,91 @@
+import { useDroppable } from "@dnd-kit/core"
+import GridListViewComponent from "../decksidebar/gridlistviewcomponent"
+import { useState } from "react"
+
+const ExtraDeckCardZone = ({ extradeckprops }: any) => {
+  const {
+    deck,
+    extraDeckCards
+  } = extradeckprops
+
+  const [listView, setListView] = useState(true);
+  const [galleryView, setGalleryView] = useState(false);
+
+  const { setNodeRef } = useDroppable({
+    id: "extradeckcard"
+  })
+
+  const filterProps = {
+    listView, setListView,
+    galleryView, setGalleryView
+  }
+
+  return (
+    <section className="flex flex-grow flex-col justify-between min-h-[30vh] w-full px-4">
+        <header className="flex w-full py-[2vh] pl-[3vw] justify-between text-[hsl(var(--text))]">
+            <span className="flex font-black items-center">Extra Deck</span>
+            <div className="flex h-fit items-center space-x-4">
+                {/*<div className="font-bold">Total Extra Deck Cards: {deck?.total_cards_extra_deck}</div>*/}
+                <div className="font-bold">Total Extra Deck Cards: {extraDeckCards.length}</div>
+                <div className='flex w-20 bg-footer rounded-xl'>
+                    <GridListViewComponent filterProps={filterProps}/>
+                </div>
+            </div>
+        </header>
+        {listView && (
+          <div className="flex bg-[hsl(var(--editdeckdraganddropbackground))] w-full min-h-[90%] rounded-xl">
+            <section
+              ref={setNodeRef}
+              className="flex flex-col w-full pt-[1.5vh] pl-[0.4vw] relative group transition-all duration-300 hover:border-2 hover:border-goldenrod hover:backdrop-blur-md hover:rounded-md"
+            >
+              {extraDeckCards.length > 0 && (
+                <div className="w-full h-full flex flex-col space-y-2 pl-2 group-hover:blur-sm transition-all duration-300">
+                  {extraDeckCards.map((card: any) => (
+                    <div
+                      key={card?.id || card?._id}
+                      className="flex h-[5vh] items-center space-x-2"
+                    >
+                      <img
+                        src={card?.card_images?.[0]?.image_url || card?.image_url}
+                        className="h-full object-contain"
+                      />
+                      <div className="font-black text-md">
+                        {card?.name || card?.card_name}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </section>
+          </div>
+        )}
+
+        {galleryView && (
+          <div className="flex bg-deckpage w-full h-[90%] rounded-lg">
+            <section ref={setNodeRef} className="flex flex-col w-full">
+              {extraDeckCards.length > 0 && ( 
+                  <div 
+                    className="grid grid-cols-8 gap-2 w-full h-full p-4 justify-items-start items-start"  
+                    style={{ gridAutoRows: 'auto', alignContent: 'start' }}
+                  >
+                    {extraDeckCards.map((card: any) => (
+                      <div className="flex h-full">
+                          <div key={card.id} className="flex h-[25%] space-x-2 bg-gray-200">
+                            <img
+                              src={card?.image_url || card?.card_images?.[0]?.image_url}
+                              className="h-full object-contain"
+                              //alt={card.card_name}
+                            />
+                          </div>
+                      </div>
+                    ))}
+                  </div>
+              )}
+            </section>
+          </div>
+        )}
+    </section>
+  )
+}
+
+export default ExtraDeckCardZone

--- a/frontend/src/components/deckcomponents/editdeckcomponents/MainDeckCardsZone.tsx
+++ b/frontend/src/components/deckcomponents/editdeckcomponents/MainDeckCardsZone.tsx
@@ -1,5 +1,6 @@
 import { useDroppable } from "@dnd-kit/core"
 import GridListViewComponent from "../decksidebar/gridlistviewcomponent"
+import { useState } from "react";
 
 const MainDeckCardZone = ({ maindeckprops }: any) => {
   const {
@@ -7,9 +8,10 @@ const MainDeckCardZone = ({ maindeckprops }: any) => {
     monsterCards,
     spellCards,
     trapCards,
-    listView, setListView,
-    galleryView, setGalleryView
   } = maindeckprops
+
+  const [listView, setListView] = useState(true);
+  const [galleryView, setGalleryView] = useState(false);
 
   const { setNodeRef: MonsterCardRef } = useDroppable({
     id: "monstercard"
@@ -29,10 +31,10 @@ const MainDeckCardZone = ({ maindeckprops }: any) => {
   }
 
   return (
-    <section className="flex flex-grow flex-col justify-between min-h-1/2 w-full p-4">
-        <header className="flex w-full py-2 pl-[3vw] justify-between text-[hsl(var(--text))]">
-            <div className="font-black">Main Deck</div>
-            <div className="flex h-full items-center space-x-4">
+    <section className="flex flex-grow flex-col justify-between min-h-[35vh] w-full px-4">
+        <header className="flex w-full py-[2vh] pl-[3vw] justify-between text-[hsl(var(--text))]">
+            <span className="flex font-black items-center">Main Deck</span>
+            <div className="flex h-fit items-center space-x-4">
                 <div className="font-bold">Total Main Deck Cards: {deck?.total_cards_main_deck}</div>
                 <div className='flex w-20 bg-footer rounded-xl'>
                     <GridListViewComponent filterProps={filterProps}/>
@@ -40,28 +42,42 @@ const MainDeckCardZone = ({ maindeckprops }: any) => {
             </div>
         </header>
         {listView && (
-          <div className="flex bg-[hsl(var(--editdeckdraganddropbackground))] w-full min-h-[90%] rounded-2xl">
-            <section ref={MonsterCardRef} className="flex flex-col w-1/3 bg-gray-400">
-              <span className="text-lg pl-[2vw] font-black text-[hsl(var(--text))]">monster: </span>
+          <div className="flex bg-[hsl(var(--editdeckdraganddropbackground))] w-full min-h-[90%] rounded-lg">
+            <section
+              ref={MonsterCardRef}
+              className="flex flex-col w-1/3 relative group transition-all duration-300 hover:border-2 hover:border-goldenrod hover:backdrop-blur-md hover:rounded-tl-lg hover:rounded-bl-lg"
+            >
+              <span className="text-lg pl-[2vw] py-[1vh] font-black text-[hsl(var(--text))] group-hover:blur-sm transition-all duration-300">
+                monster:
+              </span>
               {monsterCards.length > 0 && (
-                <div className="w-full h-full flex flex-col pl-2">
+                <div className="w-full h-full pl-[1vw] flex flex-col space-y-2 group-hover:blur-sm transition-all duration-300">
                   {monsterCards.map((card: any) => (
-                    <div key={card?.id || card?._id} className="flex h-[5vh] items-center space-x-2">
+                    <div
+                      key={card?.id || card?._id}
+                      className="flex h-[5vh] items-center space-x-2"
+                    >
                       <img
-                          src={card?.card_images?.[0]?.image_url || card?.image_url}
-                          className="h-full object-contain"
-                          //alt={card.card_name}
+                        src={card?.card_images?.[0]?.image_url || card?.image_url}
+                        className="h-full object-contain"
                       />
-                      <div className="font-black text-md">{card?.name || card?.card_name}</div>
+                      <div className="font-black text-md">
+                        {card?.name || card?.card_name}
+                      </div>
                     </div>
                   ))}
                 </div>
               )}
             </section>
-            <section ref={SpellCardRef} className="flex flex-col w-1/3 bg-red-200 h-full">
-              <span className="text-lg pl-[2vw] font-black text-[hsl(var(--text))]">Spell: </span>
+            <section 
+              ref={SpellCardRef} 
+              className="flex flex-col w-1/3 relative group transition-all duration-300 hover:border-2 hover:border-goldenrod hover:backdrop-blur-md"
+            >
+              <span className="text-lg pl-[2vw] py-[1vh] font-black text-[hsl(var(--text))] group-hover:blur-sm transition-all duration-300">
+                Spell: 
+              </span>
               {spellCards.length > 0 && (
-                <div className="w-full h-full flex flex-col pl-2">
+                <div className="w-full h-full pl-[1vw] flex flex-col space-y-2 group-hover:blur-sm transition-all duration-300">
                   {spellCards.map((card: any) => (
                     <div key={card?.id || card?._id} className="flex h-[5vh] items-center space-x-2">
                       <img
@@ -75,10 +91,12 @@ const MainDeckCardZone = ({ maindeckprops }: any) => {
                 </div>
               )}
             </section>
-            <section ref={TrapCardRef} className="w-1/3 bg-green-200 h-full">
-              <span className="text-lg pl-[2vw] font-black text-[hsl(var(--text))]">Trap: </span>
+            <section ref={TrapCardRef} className="flex flex-col w-1/3 relative group transition-all duration-300 hover:border-2 hover:border-goldenrod hover:backdrop-blur-md hover:rounded-tr-lg hover:rounded-br-lg">
+              <span className="text-lg pl-[2vw] py-[1vh] font-black text-[hsl(var(--text))] group-hover:blur-sm transition-all duration-300">
+                Trap: 
+              </span>
               {trapCards.length > 0 && (
-                <div className="w-full h-full flex flex-col pl-2">
+                <div className="w-full h-full pl-[1vw] flex flex-col space-y-2 group-hover:blur-sm transition-all duration-300">
                   {trapCards.map((card: any) => (
                     <div key={card.id} className="flex h-[5vh] items-center space-x-2">
                       <img

--- a/frontend/src/components/deckcomponents/editdeckcomponents/SideDeckCardsZone.tsx
+++ b/frontend/src/components/deckcomponents/editdeckcomponents/SideDeckCardsZone.tsx
@@ -1,0 +1,90 @@
+import { useDroppable } from "@dnd-kit/core"
+import GridListViewComponent from "../decksidebar/gridlistviewcomponent"
+import { useState } from "react"
+
+const SideDeckCardZone = ({ sidedeckprops }: any) => {
+  const {
+    deck,
+    sideDeckCards
+  } = sidedeckprops
+
+  const [listView, setListView] = useState(true);
+  const [galleryView, setGalleryView] = useState(false);
+
+  const { setNodeRef } = useDroppable({
+    id: "sidedeckcard"
+  })
+
+  const filterProps = {
+    listView, setListView,
+    galleryView, setGalleryView
+  }
+
+  return (
+    <section className="flex flex-grow flex-col min-h-[30vh] w-full px-4">
+        <header className="flex w-full py-[2vh] pl-[3vw] justify-between text-[hsl(var(--text))]">
+            <span className="flex font-black items-center">Side Deck</span>
+            <div className="flex h-fit items-center space-x-4">
+                <div className="font-bold">Total Side Deck Cards: {deck?.total_cards_side_deck}</div>
+                <div className='flex w-20 bg-footer rounded-xl'>
+                    <GridListViewComponent filterProps={filterProps}/>
+                </div>
+            </div>
+        </header>
+        {listView && (
+          <div className="flex flex-grow bg-[hsl(var(--editdeckdraganddropbackground))] w-full min-h-[90%] rounded-lg">
+            <section
+              ref={setNodeRef}
+              className="flex flex-col w-full pt-[1.5vh] pl-[0.4vw] relative group transition-all duration-300 hover:border-2 hover:border-goldenrod hover:backdrop-blur-md hover:rounded-md"
+            >
+              {sideDeckCards.length > 0 && (
+                <div className="w-full h-full flex flex-col space-y-2 pl-2 group-hover:blur-sm transition-all duration-300">
+                  {sideDeckCards.map((card: any) => (
+                    <div
+                      key={card?.id || card?._id}
+                      className="flex h-[5vh] items-center space-x-2"
+                    >
+                      <img
+                        src={card?.card_images?.[0]?.image_url || card?.image_url}
+                        className="h-full object-contain"
+                      />
+                      <div className="font-black text-md">
+                        {card?.name || card?.card_name}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </section>
+          </div>
+        )}
+
+        {galleryView && (
+          <div className="flex bg-deckpage w-full h-[90%] rounded-lg">
+            <section ref={setNodeRef} className="pt-[1.5vh] pl-[0.4vw] flex flex-col w-full">
+              {sideDeckCards.length > 0 && ( 
+                  <div 
+                    className="grid grid-cols-8 gap-2 w-full h-full p-4 justify-items-start items-start"  
+                    style={{ gridAutoRows: 'auto', alignContent: 'start' }}
+                  >
+                    {sideDeckCards.map((card: any) => (
+                      <div className="flex h-full">
+                          <div key={card.id} className="flex h-[25%] space-x-2 bg-gray-200">
+                            <img
+                              src={card?.image_url || card?.card_images?.[0]?.image_url}
+                              className="h-full object-contain"
+                              //alt={card.card_name}
+                            />
+                          </div>
+                      </div>
+                    ))}
+                  </div>
+              )}
+            </section>
+          </div>
+        )}
+    </section>
+  )
+}
+
+export default SideDeckCardZone

--- a/frontend/src/pages/my-decks/editdeckpage.tsx
+++ b/frontend/src/pages/my-decks/editdeckpage.tsx
@@ -8,6 +8,8 @@ import MainDeckCardZone from '@/components/deckcomponents/editdeckcomponents/Mai
 import { DndContext } from '@dnd-kit/core';
 import { Card, OwnedCard } from '../../components/deckcomponents/types/datatypes.ts';
 import { restrictToWindowEdges } from "@dnd-kit/modifiers"
+import ExtraDeckCardZone from '@/components/deckcomponents/editdeckcomponents/ExtraDeckCardsZone.tsx';
+import SideDeckCardZone from '@/components/deckcomponents/editdeckcomponents/SideDeckCardsZone.tsx';
 //import GridListViewComponent from '../../../components/searchbar/grid_or_list_view';
 
 const DeckBuilderPage = () => {
@@ -19,8 +21,6 @@ const DeckBuilderPage = () => {
     const [allCardsListResults, setAllCardsListResults] = useState<Card[]>([]);
     const [collectionCardsView, setCollectionCardsView] = useState(false);
     const [collectionCardData, setCollectionCardData] = useState<OwnedCard[]>([]);    
-    const [listView, setListView] = useState(true);
-    const [galleryView, setGalleryView] = useState(false);
 
     useEffect(() => {
         if (deckId && userId) {
@@ -33,6 +33,8 @@ const DeckBuilderPage = () => {
 
     const [isDropped, setIsDropped] = useState(false);
     const [mainDeckCards, setMainDeckCards] = useState<any[]>([]);
+    const [extraDeckCards, setExtraDeckCards] = useState<any[]>([]);
+    const [sideDeckCards, setSideDeckCards] = useState<any[]>([]);
     const [monsterCards, setMonsterCards] = useState<any[]>([]);
     const [spellCards, setSpellCards] = useState<any[]>([]);
     const [trapCards, setTrapCards] = useState<any[]>([]);
@@ -46,7 +48,6 @@ const DeckBuilderPage = () => {
         }
 
         if (over) {
-            console.log("snday")
             setIsDropped(true);
 
             const draggedCard = 
@@ -55,7 +56,7 @@ const DeckBuilderPage = () => {
 
             switch (over.id) {
                 case "monstercard":
-                    if (draggedCard.type?.includes("Monster")) {
+                    if (["Fusion", "Synchro", "XYZ", "Spell", "Trap"].every(type => !draggedCard.type?.includes(type))) {
                         setMainDeckCards((prev) => [...prev, draggedCard]);
                         setMonsterCards((prev) => [...prev, draggedCard]);
                     } else return;
@@ -70,6 +71,16 @@ const DeckBuilderPage = () => {
                     if (draggedCard.type?.includes("Trap")) {
                         setMainDeckCards((prev) => [...prev, draggedCard]);
                         setTrapCards((prev) => [...prev, draggedCard]);
+                    } else return;
+                    break;
+                case "extradeckcard":
+                    if (["Synchro Monster", "Fusion Monster", "XYZ Monster"].some(type => draggedCard.type?.includes(type))) {
+                        setExtraDeckCards((prev) => [...prev, draggedCard]);
+                    } else return;
+                    break;
+                case "sidedeckcard":
+                    if (draggedCard) {
+                        setSideDeckCards((prev) => [...prev, draggedCard]);
                     } else return;
                     break;
                 default:
@@ -97,8 +108,16 @@ const DeckBuilderPage = () => {
         monsterCards,
         spellCards,
         trapCards,
-        listView, setListView,
-        galleryView, setGalleryView
+    }
+
+    const extradeckprops = {
+        deck,
+        extraDeckCards
+    }
+
+    const sidedeckprops = {
+        deck,
+        sideDeckCards
     }
 
     /*const filterProps = {
@@ -128,20 +147,16 @@ const DeckBuilderPage = () => {
                                 </section>
                             </header>
                             <main className="flex flex-col flex-grow min-h-[87vh] bg-transparent">
-                                    <MainDeckCardZone maindeckprops={maindeckprops}/>
-                                    <section className="min-h-[25vh] w-full p-4 justify-between flex flex-col">
-                                        < header className="flex w-full px-[3vw] justify-between text-[hsl(var(--text))]">
-                                            <div className="font-black">Extra Deck</div>
-                                            <div className="font-bold">Total Extra Deck Cards: {deck?.total_cards_extra_deck}</div>
-                                        </header>
-                                        <div className="bg-deckpage w-full h-[80%] rounded-2xl"></div>
+                                    <section className="flex mb-[10vh]">
+                                        <MainDeckCardZone maindeckprops={maindeckprops}/>
                                     </section>
-                                    <section className="min-h-[25vh] w-full p-4 justify-between">
-                                        <header className="flex w-full px-[3vw] justify-between text-[hsl(var(--text))]">
-                                            <div className="font-black">Side Deck</div>
-                                            <div className="font-bold">Total Side Cards: {deck?.total_cards_side_deck}</div>
-                                        </header>
-                                        <div className="bg-deckpage w-full h-[90%] rounded-2xl"></div>
+                                    <section className="flex w-full mb-[10vh]">
+                                        <div className="flex w-1/2">
+                                            <ExtraDeckCardZone extradeckprops={extradeckprops}/>
+                                        </div>
+                                        <div className="flex w-1/2">
+                                            <SideDeckCardZone sidedeckprops={sidedeckprops}/>
+                                        </div>
                                     </section>
                             </main>
                         </section>

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -53,7 +53,8 @@ export default {
   		boxShadow: {
   			custom: '0 4px 30px rgba(0, 0, 0, 0.5)',
   			mycards: '0px 0px 15px rgb(19, 18, 18)',
-			dropdow: '0 0px 4px 0px hsl(var(--shadow-color))'
+			dropdow: '0 0px 4px 0px hsl(var(--shadow-color))',
+			'inner-border': 'inset 0 0 0 4px rgba(55, 65, 81, 1)'
   		},
   		keyframes: {
 			skFoldCube: {


### PR DESCRIPTION
- Finished Hover functionality to blur the section elements for better ux/display for when the user is hovering over a certain section
- Finished drag/drop functionality for Side/Extra Deck along with their filters
- Need to work on additonal functionalities like:
   - hover display for gallery view
   - mouse functionality like right clicking to add to card
   - A counter to display how many monster/spell/trap and extra/side deck cards
   - A counter to display how many of one card you are adding
   - A limiter to each drag/drop zone so user can't add more than 
     - 60 cards for main deck
     - 15 cards for extra deck/side deck
   - Functionality to save all the added cards to db
- Need to fix issue with adding duplicate cards showing up as different entries in the zone instead of one card entry with the amount of the card the user is adding