### PR TITLE
Modified Blur functionality to only work when correct card is hovered

### DIFF
--- a/frontend/src/components/deckcomponents/draganddropitems/CollectionListViewItem.tsx
+++ b/frontend/src/components/deckcomponents/draganddropitems/CollectionListViewItem.tsx
@@ -1,6 +1,5 @@
 import { useDraggable } from '@dnd-kit/core';
 import { CSS } from '@dnd-kit/utilities';
-import { useEffect } from 'react';
 
 const CollectionListViewItem = ({ result }: { result: any }) => {
     const { attributes, listeners, setNodeRef, transform } = useDraggable({
@@ -9,10 +8,6 @@ const CollectionListViewItem = ({ result }: { result: any }) => {
     const style = {
         transform: CSS.Translate.toString(transform),
     };
-
-    /*useEffect(() => {
-            console.log("2", result._id)
-    })*/
 
     return (
         <div

--- a/frontend/src/components/deckcomponents/draganddropitems/SearchCardListViewItem.tsx
+++ b/frontend/src/components/deckcomponents/draganddropitems/SearchCardListViewItem.tsx
@@ -1,6 +1,5 @@
 import { useDraggable } from '@dnd-kit/core';
 import { CSS } from '@dnd-kit/utilities';
-import { useEffect } from 'react';
 
 const SearchCardListViewItem = ({ card }: { card: any }) => {
     const { attributes, listeners, setNodeRef, transform } = useDraggable({
@@ -9,10 +8,6 @@ const SearchCardListViewItem = ({ card }: { card: any }) => {
     const style = {
         transform: CSS.Translate.toString(transform),
     };
-
-    /*useEffect(() => {
-        console.log("1", card.id)
-    })*/
 
     return (
         <div

--- a/frontend/src/components/deckcomponents/editdeckcomponents/ExtraDeckCardsZone.tsx
+++ b/frontend/src/components/deckcomponents/editdeckcomponents/ExtraDeckCardsZone.tsx
@@ -4,16 +4,21 @@ import { useState } from "react"
 
 const ExtraDeckCardZone = ({ extradeckprops }: any) => {
   const {
-    deck,
-    extraDeckCards
+    //deck,
+    extraDeckCards,
+    hoveredCard
   } = extradeckprops
 
   const [listView, setListView] = useState(true);
   const [galleryView, setGalleryView] = useState(false);
 
-  const { setNodeRef } = useDroppable({
+  const { setNodeRef, isOver } = useDroppable({
     id: "extradeckcard"
   })
+
+  const shouldExtraDeckBlur = isOver && hoveredCard && ["Synchro Monster", "Fusion Monster", "XYZ Monster"].some(
+    (type) => hoveredCard.type?.includes(type)
+  );
 
   const filterProps = {
     listView, setListView,
@@ -36,10 +41,12 @@ const ExtraDeckCardZone = ({ extradeckprops }: any) => {
           <div className="flex bg-[hsl(var(--editdeckdraganddropbackground))] w-full min-h-[90%] rounded-xl">
             <section
               ref={setNodeRef}
-              className="flex flex-col w-full pt-[1.5vh] pl-[0.4vw] relative group transition-all duration-300 hover:border-2 hover:border-goldenrod hover:backdrop-blur-md hover:rounded-md"
+              className={`flex flex-col w-full pt-[1.5vh] pl-[0.4vw] relative group transition-all duration-300 ${
+                shouldExtraDeckBlur ? "blur-sm border-2 border-goldenrod rounded-tl-lg rounded-bl-lg" : ""
+              }`}
             >
               {extraDeckCards.length > 0 && (
-                <div className="w-full h-full flex flex-col space-y-2 pl-2 group-hover:blur-sm transition-all duration-300">
+                <div className="w-full h-full flex flex-col space-y-2 pl-2">
                   {extraDeckCards.map((card: any) => (
                     <div
                       key={card?.id || card?._id}

--- a/frontend/src/components/deckcomponents/editdeckcomponents/MainDeckCardsZone.tsx
+++ b/frontend/src/components/deckcomponents/editdeckcomponents/MainDeckCardsZone.tsx
@@ -8,22 +8,31 @@ const MainDeckCardZone = ({ maindeckprops }: any) => {
     monsterCards,
     spellCards,
     trapCards,
+    hoveredCard
   } = maindeckprops
 
   const [listView, setListView] = useState(true);
   const [galleryView, setGalleryView] = useState(false);
 
-  const { setNodeRef: MonsterCardRef } = useDroppable({
+  const { setNodeRef: MonsterCardRef, isOver: isMonsterOver } = useDroppable({
     id: "monstercard"
   })
 
-  const { setNodeRef: SpellCardRef } = useDroppable({
+  const shouldMonsterBlur = isMonsterOver && hoveredCard && ["Fusion", "Synchro", "XYZ", "Spell", "Trap"].every(
+      (type) => !hoveredCard.type?.includes(type)
+  );
+
+  const { setNodeRef: SpellCardRef, isOver: isSpellOver } = useDroppable({
     id: "spellcard"
   })
 
-  const { setNodeRef: TrapCardRef } = useDroppable({
+  const shouldSpellBlur = isSpellOver && hoveredCard && hoveredCard?.type?.includes("Spell");
+
+  const { setNodeRef: TrapCardRef, isOver: isTrapOver } = useDroppable({
     id: "trapcard"
   })
+
+  const shouldTrapBlur = isTrapOver && hoveredCard && hoveredCard?.type?.includes("Trap");
 
   const filterProps = {
     listView, setListView,
@@ -45,13 +54,15 @@ const MainDeckCardZone = ({ maindeckprops }: any) => {
           <div className="flex bg-[hsl(var(--editdeckdraganddropbackground))] w-full min-h-[90%] rounded-lg">
             <section
               ref={MonsterCardRef}
-              className="flex flex-col w-1/3 relative group transition-all duration-300 hover:border-2 hover:border-goldenrod hover:backdrop-blur-md hover:rounded-tl-lg hover:rounded-bl-lg"
+              className={`flex flex-col w-1/3 relative group transition-all duration-300 ${
+                shouldMonsterBlur ? "blur-sm border-2 border-goldenrod rounded-tl-lg rounded-bl-lg" : ""
+              }`}
             >
-              <span className="text-lg pl-[2vw] py-[1vh] font-black text-[hsl(var(--text))] group-hover:blur-sm transition-all duration-300">
+              <span className="text-lg pl-[2vw] py-[1vh] font-black text-[hsl(var(--text))]">
                 monster:
               </span>
               {monsterCards.length > 0 && (
-                <div className="w-full h-full pl-[1vw] flex flex-col space-y-2 group-hover:blur-sm transition-all duration-300">
+                <div className="w-full h-full pl-[1vw] flex flex-col space-y-2">
                   {monsterCards.map((card: any) => (
                     <div
                       key={card?.id || card?._id}
@@ -71,13 +82,15 @@ const MainDeckCardZone = ({ maindeckprops }: any) => {
             </section>
             <section 
               ref={SpellCardRef} 
-              className="flex flex-col w-1/3 relative group transition-all duration-300 hover:border-2 hover:border-goldenrod hover:backdrop-blur-md"
+              className={`flex flex-col w-1/3 relative group transition-all duration-300 ${
+                shouldSpellBlur ? "blur-sm border-2 border-goldenrod" : ""
+              }`}
             >
-              <span className="text-lg pl-[2vw] py-[1vh] font-black text-[hsl(var(--text))] group-hover:blur-sm transition-all duration-300">
+              <span className="text-lg pl-[2vw] py-[1vh] font-black text-[hsl(var(--text))]">
                 Spell: 
               </span>
               {spellCards.length > 0 && (
-                <div className="w-full h-full pl-[1vw] flex flex-col space-y-2 group-hover:blur-sm transition-all duration-300">
+                <div className="w-full h-full pl-[1vw] flex flex-col space-y-2">
                   {spellCards.map((card: any) => (
                     <div key={card?.id || card?._id} className="flex h-[5vh] items-center space-x-2">
                       <img
@@ -91,12 +104,17 @@ const MainDeckCardZone = ({ maindeckprops }: any) => {
                 </div>
               )}
             </section>
-            <section ref={TrapCardRef} className="flex flex-col w-1/3 relative group transition-all duration-300 hover:border-2 hover:border-goldenrod hover:backdrop-blur-md hover:rounded-tr-lg hover:rounded-br-lg">
-              <span className="text-lg pl-[2vw] py-[1vh] font-black text-[hsl(var(--text))] group-hover:blur-sm transition-all duration-300">
+            <section 
+              ref={TrapCardRef} 
+              className={`flex flex-col w-1/3 relative group transition-all duration-300 ${
+                shouldTrapBlur ? "blur-sm border-2 border-goldenrod" : ""
+              }`}
+            >
+              <span className="text-lg pl-[2vw] py-[1vh] font-black text-[hsl(var(--text))]">
                 Trap: 
               </span>
               {trapCards.length > 0 && (
-                <div className="w-full h-full pl-[1vw] flex flex-col space-y-2 group-hover:blur-sm transition-all duration-300">
+                <div className="w-full h-full pl-[1vw] flex flex-col space-y-2">
                   {trapCards.map((card: any) => (
                     <div key={card.id} className="flex h-[5vh] items-center space-x-2">
                       <img

--- a/frontend/src/components/deckcomponents/editdeckcomponents/SideDeckCardsZone.tsx
+++ b/frontend/src/components/deckcomponents/editdeckcomponents/SideDeckCardsZone.tsx
@@ -5,15 +5,18 @@ import { useState } from "react"
 const SideDeckCardZone = ({ sidedeckprops }: any) => {
   const {
     deck,
-    sideDeckCards
+    sideDeckCards,
+    hoveredCard
   } = sidedeckprops
 
   const [listView, setListView] = useState(true);
   const [galleryView, setGalleryView] = useState(false);
 
-  const { setNodeRef } = useDroppable({
+  const { setNodeRef, isOver } = useDroppable({
     id: "sidedeckcard"
   })
+
+  const shouldSideDeckBlur = isOver && hoveredCard;
 
   const filterProps = {
     listView, setListView,
@@ -35,7 +38,9 @@ const SideDeckCardZone = ({ sidedeckprops }: any) => {
           <div className="flex flex-grow bg-[hsl(var(--editdeckdraganddropbackground))] w-full min-h-[90%] rounded-lg">
             <section
               ref={setNodeRef}
-              className="flex flex-col w-full pt-[1.5vh] pl-[0.4vw] relative group transition-all duration-300 hover:border-2 hover:border-goldenrod hover:backdrop-blur-md hover:rounded-md"
+              className={`flex flex-col w-full pt-[1.5vh] pl-[0.4vw] relative group transition-all duration-300 ${
+                shouldSideDeckBlur ? "blur-sm border-2 border-goldenrod rounded-tl-lg rounded-bl-lg" : ""
+              }`}
             >
               {sideDeckCards.length > 0 && (
                 <div className="w-full h-full flex flex-col space-y-2 pl-2 group-hover:blur-sm transition-all duration-300">

--- a/frontend/src/pages/my-decks/editdeckpage.tsx
+++ b/frontend/src/pages/my-decks/editdeckpage.tsx
@@ -10,7 +10,6 @@ import { Card, OwnedCard } from '../../components/deckcomponents/types/datatypes
 import { restrictToWindowEdges } from "@dnd-kit/modifiers"
 import ExtraDeckCardZone from '@/components/deckcomponents/editdeckcomponents/ExtraDeckCardsZone.tsx';
 import SideDeckCardZone from '@/components/deckcomponents/editdeckcomponents/SideDeckCardsZone.tsx';
-//import GridListViewComponent from '../../../components/searchbar/grid_or_list_view';
 
 const DeckBuilderPage = () => {
     const location = useLocation();
@@ -32,12 +31,32 @@ const DeckBuilderPage = () => {
     const deck = deckData?.entities?.undefined?.[0];
 
     const [isDropped, setIsDropped] = useState(false);
+    const [hoveredCard, setHoveredCard] = useState<any>(null);
     const [mainDeckCards, setMainDeckCards] = useState<any[]>([]);
     const [extraDeckCards, setExtraDeckCards] = useState<any[]>([]);
     const [sideDeckCards, setSideDeckCards] = useState<any[]>([]);
     const [monsterCards, setMonsterCards] = useState<any[]>([]);
     const [spellCards, setSpellCards] = useState<any[]>([]);
     const [trapCards, setTrapCards] = useState<any[]>([]);
+
+    const handleDragMove = (event: any) => {
+        const { active } = event;
+    
+        if (!active?.id) {
+            setHoveredCard(null);
+            return;
+        }
+    
+        const draggedCard: any =
+            allCardsListResults.find((card) => card.id === active.id) ||
+            collectionCardData.find((card) => card._id === active.id);
+    
+        setHoveredCard(draggedCard);
+    };
+
+    const handleDragLeave = () => {
+        setHoveredCard(null);
+    };
 
     const handleDragEnd = (event: any) => {
         const { active, over } = event;
@@ -50,7 +69,7 @@ const DeckBuilderPage = () => {
         if (over) {
             setIsDropped(true);
 
-            const draggedCard = 
+            const draggedCard: any = 
                 allCardsListResults.find((card) => card.id === active.id) || 
                 collectionCardData.find((card) => card._id === active.id);
 
@@ -59,7 +78,7 @@ const DeckBuilderPage = () => {
                     if (["Fusion", "Synchro", "XYZ", "Spell", "Trap"].every(type => !draggedCard.type?.includes(type))) {
                         setMainDeckCards((prev) => [...prev, draggedCard]);
                         setMonsterCards((prev) => [...prev, draggedCard]);
-                    } else return;
+                    } else return
                     break;
                 case "spellcard":
                     if (draggedCard.type?.includes("Spell")) {
@@ -108,16 +127,19 @@ const DeckBuilderPage = () => {
         monsterCards,
         spellCards,
         trapCards,
+        hoveredCard
     }
 
     const extradeckprops = {
         deck,
-        extraDeckCards
+        extraDeckCards,
+        hoveredCard
     }
 
     const sidedeckprops = {
         deck,
-        sideDeckCards
+        sideDeckCards,
+        hoveredCard
     }
 
     /*const filterProps = {
@@ -132,7 +154,7 @@ const DeckBuilderPage = () => {
         <Header/>
             <main className="flex w-full min-h-[110vh] bg-[hsl(var(--background1))]">           
                 {!isLoading && deckData && (
-                    <DndContext onDragEnd={handleDragEnd} modifiers={[restrictToWindowEdges]}>
+                    <DndContext onDragCancel={handleDragLeave} onDragMove={handleDragMove} onDragEnd={handleDragEnd} modifiers={[restrictToWindowEdges]}>
                         <section className="flex flex-col w-[80vw] pt-[76px]">
                             <header className="flex justify-between items-center p-5 w-full h-[17vh] bg-gradient-to-t from-[hsl(var(--homepagegradient1))] to-[hsl(var(--homepagegradient3))]">
                                 <section className="flex flex-col h-full justify-between">


### PR DESCRIPTION
- Modified Blur Functionality to only work when correct card is hovered. ie: Monster Card is hovered over the monster card section
- Need to work on additonal functionalities like:
   - hover display for gallery view
   - mouse functionality like right clicking to add to card
   - A counter to display how many monster/spell/trap and extra/side deck cards
   - A counter to display how many of one card you are adding
   - A limiter to each drag/drop zone so user can't add more than
     - 60 cards for main deck
     - 15 cards for extra deck/side deck
   - Functionality to save all the added cards to db
- Need to fix issue with adding duplicate cards showing up as different entries in the zone instead of one card entry with the amount of the card the user is adding