### PR TITLE
Finished blur functionality for gallery view

### DIFF
--- a/frontend/src/components/deckcomponents/editdeckcomponents/ExtraDeckCardsZone.tsx
+++ b/frontend/src/components/deckcomponents/editdeckcomponents/ExtraDeckCardsZone.tsx
@@ -68,16 +68,21 @@ const ExtraDeckCardZone = ({ extradeckprops }: any) => {
         )}
 
         {galleryView && (
-          <div className="flex bg-deckpage w-full h-[90%] rounded-lg">
-            <section ref={setNodeRef} className="flex flex-col w-full">
+          <div className="flex bg-[hsl(var(--editdeckdraganddropbackground))] w-full min-h-[90%] rounded-xl">
+            <section 
+              ref={setNodeRef} 
+              className={`flex flex-col w-full pt-[1.5vh] pl-[0.4vw] relative group transition-all duration-300 ${
+                shouldExtraDeckBlur ? "blur-sm border-2 border-goldenrod rounded-tl-lg rounded-bl-lg" : ""
+              }`}
+            >
               {extraDeckCards.length > 0 && ( 
                   <div 
-                    className="grid grid-cols-8 gap-2 w-full h-full p-4 justify-items-start items-start"  
+                    className="grid grid-cols-8 gap-4 w-full h-full p-4 justify-items-start items-start"  
                     style={{ gridAutoRows: 'auto', alignContent: 'start' }}
                   >
                     {extraDeckCards.map((card: any) => (
                       <div className="flex h-full">
-                          <div key={card.id} className="flex h-[25%] space-x-2 bg-gray-200">
+                          <div key={card.id} className="flex">
                             <img
                               src={card?.image_url || card?.card_images?.[0]?.image_url}
                               className="h-full object-contain"

--- a/frontend/src/components/deckcomponents/editdeckcomponents/MainDeckCardsZone.tsx
+++ b/frontend/src/components/deckcomponents/editdeckcomponents/MainDeckCardsZone.tsx
@@ -132,17 +132,22 @@ const MainDeckCardZone = ({ maindeckprops }: any) => {
         )}
 
         {galleryView && (
-          <div className="flex bg-deckpage w-full h-[90%] rounded-2xl">
-            <section ref={MonsterCardRef} className="flex flex-col w-1/3 bg-gray-400">
+          <div className="flex bg-[hsl(var(--editdeckdraganddropbackground))] w-full min-h-[90%] rounded-lg">
+            <section 
+              ref={MonsterCardRef} 
+              className={`flex flex-col w-1/3 relative group transition-all duration-300 ${
+                shouldMonsterBlur ? "blur-sm border-2 border-goldenrod rounded-tl-lg rounded-bl-lg" : ""
+              }`}
+            >
               <span className="text-lg pl-[2vw] pt-[2vh] font-black text-[hsl(var(--text))]">Monster: </span>
               {monsterCards.length > 0 && ( 
                   <div 
-                    className="grid grid-cols-8 gap-2 w-full h-full p-4 justify-items-start items-start"  
+                    className="grid grid-cols-6 gap-4 w-full h-full p-4 justify-items-start items-start"  
                     style={{ gridAutoRows: 'auto', alignContent: 'start' }}
                   >
                     {monsterCards.map((card: any) => (
                       <div className="flex h-full">
-                          <div key={card.id} className="flex h-[25%] space-x-2 bg-gray-200">
+                          <div key={card.id} className="flex">
                             <img
                               src={card?.image_url || card?.card_images?.[0]?.image_url}
                               className="h-full object-contain"
@@ -155,16 +160,21 @@ const MainDeckCardZone = ({ maindeckprops }: any) => {
               )}
             </section>
 
-            <section ref={SpellCardRef} className="flex flex-col w-1/3">
+            <section 
+              ref={SpellCardRef} 
+              className={`flex flex-col w-1/3 relative group transition-all duration-300 ${
+                shouldSpellBlur ? "blur-sm border-2 border-goldenrod" : ""
+              }`}
+            >
               <span className="text-lg pl-[2vw] pt-[2vh] font-black text-[hsl(var(--text))]">Spell: </span>
               {spellCards.length > 0 && (
                   <div 
-                    className="grid grid-cols-8 gap-2 w-full h-full p-4 justify-items-start items-start"  
+                    className="grid grid-cols-6 gap-4 w-full h-full p-4 justify-items-start items-start"  
                     style={{ gridAutoRows: 'auto', alignContent: 'start' }}
                   >
                     {spellCards.map((card: any) => (
                       <div className="flex h-full">
-                          <div key={card.id} className="flex h-[25%] space-x-2 bg-gray-200">
+                          <div key={card.id} className="flex">
                             <img
                               src={card?.image_url || card?.card_images?.[0]?.image_url}
                               className="h-full object-contain"
@@ -177,16 +187,21 @@ const MainDeckCardZone = ({ maindeckprops }: any) => {
               )}
             </section>
 
-            <section ref={TrapCardRef} className="flex flex-col w-1/3">
+            <section 
+              ref={TrapCardRef} 
+              className={`flex flex-col w-1/3 relative group transition-all duration-300 ${
+                shouldTrapBlur ? "blur-sm border-2 border-goldenrod" : ""
+              }`}
+            >
               <span className="text-lg pl-[2vw] pt-[2vh] font-black text-[hsl(var(--text))]">Trap: </span>
               {trapCards.length > 0 && ( 
                   <div 
-                    className="grid grid-cols-8 gap-2 w-full h-full p-4 justify-items-start items-start"  
+                    className="grid grid-cols-6 gap-4 w-full h-full p-4 justify-items-start items-start"  
                     style={{ gridAutoRows: 'auto', alignContent: 'start' }}
                   >
                     {trapCards.map((card: any) => (
                       <div className="flex h-full">
-                          <div key={card.id} className="flex h-[25%] space-x-2 bg-gray-200">
+                          <div key={card.id} className="flex">
                             <img
                               src={card?.image_url || card?.card_images?.[0]?.image_url}
                               className="h-full object-contain"

--- a/frontend/src/components/deckcomponents/editdeckcomponents/SideDeckCardsZone.tsx
+++ b/frontend/src/components/deckcomponents/editdeckcomponents/SideDeckCardsZone.tsx
@@ -16,7 +16,7 @@ const SideDeckCardZone = ({ sidedeckprops }: any) => {
     id: "sidedeckcard"
   })
 
-  const shouldSideDeckBlur = isOver && hoveredCard;
+  const shouldSideDeckBlur = isOver && hoveredCard ;
 
   const filterProps = {
     listView, setListView,
@@ -43,7 +43,7 @@ const SideDeckCardZone = ({ sidedeckprops }: any) => {
               }`}
             >
               {sideDeckCards.length > 0 && (
-                <div className="w-full h-full flex flex-col space-y-2 pl-2 group-hover:blur-sm transition-all duration-300">
+                <div className="w-full h-full flex flex-col space-y-2 pl-2">
                   {sideDeckCards.map((card: any) => (
                     <div
                       key={card?.id || card?._id}
@@ -65,16 +65,21 @@ const SideDeckCardZone = ({ sidedeckprops }: any) => {
         )}
 
         {galleryView && (
-          <div className="flex bg-deckpage w-full h-[90%] rounded-lg">
-            <section ref={setNodeRef} className="pt-[1.5vh] pl-[0.4vw] flex flex-col w-full">
+          <div className="flex flex-grow bg-[hsl(var(--editdeckdraganddropbackground))] w-full min-h-[90%] rounded-lg">
+            <section 
+              ref={setNodeRef} 
+              className={`flex flex-col w-full pt-[1.5vh] pl-[0.4vw] relative group transition-all duration-300 ${
+                shouldSideDeckBlur ? "blur-sm border-2 border-goldenrod rounded-tl-lg rounded-bl-lg" : ""
+              }`}
+            >
               {sideDeckCards.length > 0 && ( 
                   <div 
-                    className="grid grid-cols-8 gap-2 w-full h-full p-4 justify-items-start items-start"  
+                    className="grid grid-cols-8 gap-4 w-full h-full p-4 justify-items-start items-start"  
                     style={{ gridAutoRows: 'auto', alignContent: 'start' }}
                   >
                     {sideDeckCards.map((card: any) => (
                       <div className="flex h-full">
-                          <div key={card.id} className="flex h-[25%] space-x-2 bg-gray-200">
+                          <div key={card.id} className="flex">
                             <img
                               src={card?.image_url || card?.card_images?.[0]?.image_url}
                               className="h-full object-contain"


### PR DESCRIPTION
- Finished blur functionality for gallery View on correct card hover
- Need to work on additonal functionalities like:
  - mouse functionality like right clicking to add to card
  - A counter to display how many monster/spell/trap and extra/side deck cards
  - A counter to display how many of one card you are adding
  - A limiter to each drag/drop zone so user can't add more than 
    - 60 cards for main deck
    - 15 cards for extra deck/side deck
  - Functionality to save all the added cards to db
- Need to fix issue with adding duplicate cards showing up as different entries in the zone instead of one card entry with the amount of the card the user is adding