### PR TITLE
Added functionality for hovered tab to show site url

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,7 @@
 
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" charset="utf-8" />
-    <title>Vite + React + TS + MEEEEEEEEEEE</title>
+    <title>Atlaxiom</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,6 @@
-import { Routes, Route } from 'react-router-dom'
+import { Routes, Route, useLocation } from 'react-router-dom'
 import StayLoggedIn from './features/auth/stayloggedin.tsx';
-import { lazy, Suspense } from 'react';
+import { lazy, Suspense, useEffect } from 'react';
 import FoldingCube from './components/loadingcomponents/foldingcube.tsx';
 
 const SearchResults = lazy(() => (import('./pages/searchpage/searchresults.tsx')))
@@ -16,6 +16,12 @@ const DeckBuilderPage = lazy(() => import("./pages/my-decks/editdeckpage.tsx"))
 const Profilepage = lazy(() => import("./pages/profilepage/Profilepage.tsx"))
 
 function App() {
+  const location = useLocation();
+
+  useEffect(() => {
+    document.title = window.location.href;
+  }, [location]);
+
   return (
     <Suspense fallback={<FoldingCube/>}>
       <Routes>


### PR DESCRIPTION
Added logic so when hovering the site on a tab, it will display the current url/subpage instead of the vite + react header